### PR TITLE
Improve action creators' type safety

### DIFF
--- a/src/actionCreators.ts
+++ b/src/actionCreators.ts
@@ -2,13 +2,13 @@ import { SHARED, CLIENT } from './tags';
 import {CONNECT} from "./actions";
 
 export const shared =
-    (actionCreator: Function) => (...args: any[]) => ({
+    <T extends (...args: any[]) => any>(actionCreator: T) => (...args: Parameters<T>) => ({
         [SHARED]: true,
         ...actionCreator(...args)
     });
 
 export const client =
-    (actionCreator: Function) => (...args: any[]) => ({
+    <T extends (...args: any[]) => any>(actionCreator: T) => (...args: Parameters<T>) => ({
         [SHARED]: true,
         [CLIENT]: true,
         ...actionCreator(...args)


### PR DESCRIPTION
Action creators created with `shared` or `client` helpers lose their argument's types. By making them generic, we can preserve the types, making their usage safer.

Example:
```ts
import { client } from 'redux-socket-client'

const exampleActionCreator = client((id: string, index: number) => ({
    type: 'EXAMPLE_ACTION',
    payload: { id, index }
}))

/**
 * Before the change this line causes no compiler error
 * After the change: Argument of type '5' is not assignable to parameter of type 'string'
*/
exampleActionCreator(5, 5)

```